### PR TITLE
feat: add premium foundation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
 
 import { ThemeProvider } from "./context/ThemeContext";
+import { PremiumProvider } from "./context/PremiumContext";
 import HomeScreen from "./screens/HomeScreen";
 import ExploreScreen from "./screens/ExploreScreen";
 import MapScreen from "./screens/MapScreen";
@@ -52,50 +53,52 @@ export default function App() {
   }, []);
 
   return (
-    <ThemeProvider isDarkMode={isDarkMode} toggleTheme={toggleTheme}>
-      <NavigationContainer>
-        <Stack.Navigator
-          initialRouteName="Home"
-          screenOptions={{ headerShown: false }}
-        >
-          <Stack.Screen
-            name="Home"
-            component={HomeScreen}
-            options={{ title: "World Explorer" }}
-          />
-          <Stack.Screen
-            name="Explore"
-            component={ExploreScreen}
-            options={{ title: t("explore") }}
-          />
-          <Stack.Screen
-            name="Map"
-            component={MapScreen}
-            options={{ title: t("map") }}
-          />
-          <Stack.Screen
-            name="Quiz"
-            component={QuizScreen}
-            options={{ title: t("quiz") }}
-          />
-          <Stack.Screen
-            name="QuizResults"
-            component={QuizResultsScreen}
-            options={{ title: t("yourScore") }}
-          />
-          <Stack.Screen
-            name="Settings"
-            component={SettingsScreen}
-            options={{ title: t("settings") }}
-          />
-          <Stack.Screen
-            name="CountryDetails"
-            component={CountryDetailsScreen}
-            options={{ title: t("countryDetails") }}
-          />
-        </Stack.Navigator>
-        <Toast />
-      </NavigationContainer>
-    </ThemeProvider>
+    <PremiumProvider>
+      <ThemeProvider isDarkMode={isDarkMode} toggleTheme={toggleTheme}>
+        <NavigationContainer>
+          <Stack.Navigator
+            initialRouteName="Home"
+            screenOptions={{ headerShown: false }}
+          >
+            <Stack.Screen
+              name="Home"
+              component={HomeScreen}
+              options={{ title: "World Explorer" }}
+            />
+            <Stack.Screen
+              name="Explore"
+              component={ExploreScreen}
+              options={{ title: t("explore") }}
+            />
+            <Stack.Screen
+              name="Map"
+              component={MapScreen}
+              options={{ title: t("map") }}
+            />
+            <Stack.Screen
+              name="Quiz"
+              component={QuizScreen}
+              options={{ title: t("quiz") }}
+            />
+            <Stack.Screen
+              name="QuizResults"
+              component={QuizResultsScreen}
+              options={{ title: t("yourScore") }}
+            />
+            <Stack.Screen
+              name="Settings"
+              component={SettingsScreen}
+              options={{ title: t("settings") }}
+            />
+            <Stack.Screen
+              name="CountryDetails"
+              component={CountryDetailsScreen}
+              options={{ title: t("countryDetails") }}
+            />
+          </Stack.Navigator>
+          <Toast />
+        </NavigationContainer>
+      </ThemeProvider>
+    </PremiumProvider>
   );
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+  <uses-permission android:name="com.android.vending.BILLING"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>

--- a/app.config.js
+++ b/app.config.js
@@ -26,6 +26,7 @@ module.exports = {
     android: {
       package: "com.adateo.WorldExplorer",
       versionCode: 91,
+      permissions: ["com.android.vending.BILLING"],
       adaptiveIcon: {
         foregroundImage: "./assets/adaptive-icon.png",
         backgroundColor: "#ffffff",
@@ -64,6 +65,13 @@ module.exports = {
       ADMOB_APP_ID: admobAndroidAppId,
       ADMOB_BANNER_ID: process.env.ADMOB_BANNER_ID,
       ADMOB_INTERSTITIAL_ID: process.env.ADMOB_INTERSTITIAL_ID,
+      EXPO_PUBLIC_PREMIUM_ENABLED: process.env.EXPO_PUBLIC_PREMIUM_ENABLED,
+      EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY:
+        process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY,
+      EXPO_PUBLIC_REVENUECAT_IOS_API_KEY:
+        process.env.EXPO_PUBLIC_REVENUECAT_IOS_API_KEY,
+      EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID:
+        process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID,
       FIREBASE_APP_ID: process.env.FIREBASE_APP_ID,
       FIREBASE_PROJECT_ID: process.env.FIREBASE_PROJECT_ID,
       FIREBASE_API_KEY: process.env.FIREBASE_API_KEY,

--- a/context/PremiumContext.js
+++ b/context/PremiumContext.js
@@ -46,8 +46,15 @@ export const PremiumProvider = ({ children }) => {
       return;
     }
 
-    const customerInfo = await Purchases.getCustomerInfo();
-    applyCustomerInfo(customerInfo);
+    try {
+      const customerInfo = await Purchases.getCustomerInfo();
+      applyCustomerInfo(customerInfo);
+      setError(null);
+    } catch (refreshError) {
+      setError(
+        refreshError?.message || "RevenueCat customer info refresh failed."
+      );
+    }
   }, [applyCustomerInfo, isConfigured]);
 
   React.useEffect(() => {

--- a/context/PremiumContext.js
+++ b/context/PremiumContext.js
@@ -1,0 +1,124 @@
+import React from "react";
+import { Platform } from "react-native";
+import Purchases, { LOG_LEVEL } from "react-native-purchases";
+
+const PREMIUM_ENABLED = process.env.EXPO_PUBLIC_PREMIUM_ENABLED === "true";
+const PREMIUM_ENTITLEMENT_ID =
+  process.env.EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID || "premium";
+
+const REVENUECAT_API_KEYS = {
+  android: process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY,
+  ios: process.env.EXPO_PUBLIC_REVENUECAT_IOS_API_KEY,
+};
+
+const PremiumContext = React.createContext({
+  isPremium: false,
+  isConfigured: false,
+  isEnabled: false,
+  isLoading: false,
+  error: null,
+  refreshCustomerInfo: async () => {},
+});
+
+const hasPremiumEntitlement = (customerInfo) =>
+  Boolean(customerInfo?.entitlements?.active?.[PREMIUM_ENTITLEMENT_ID]);
+
+const getRevenueCatApiKey = () => {
+  if (Platform.OS !== "android" && Platform.OS !== "ios") {
+    return undefined;
+  }
+
+  return REVENUECAT_API_KEYS[Platform.OS];
+};
+
+export const PremiumProvider = ({ children }) => {
+  const [isPremium, setIsPremium] = React.useState(false);
+  const [isConfigured, setIsConfigured] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(PREMIUM_ENABLED);
+  const [error, setError] = React.useState(null);
+
+  const applyCustomerInfo = React.useCallback((customerInfo) => {
+    setIsPremium(hasPremiumEntitlement(customerInfo));
+  }, []);
+
+  const refreshCustomerInfo = React.useCallback(async () => {
+    if (!isConfigured) {
+      return;
+    }
+
+    const customerInfo = await Purchases.getCustomerInfo();
+    applyCustomerInfo(customerInfo);
+  }, [applyCustomerInfo, isConfigured]);
+
+  React.useEffect(() => {
+    let isMounted = true;
+
+    if (!PREMIUM_ENABLED) {
+      setIsLoading(false);
+      return undefined;
+    }
+
+    const apiKey = getRevenueCatApiKey();
+
+    if (!apiKey) {
+      setIsLoading(false);
+      setError("RevenueCat API key is missing.");
+      return undefined;
+    }
+
+    const customerInfoListener = (customerInfo) => {
+      if (isMounted) {
+        applyCustomerInfo(customerInfo);
+      }
+    };
+
+    const configurePurchases = async () => {
+      try {
+        Purchases.setLogLevel(__DEV__ ? LOG_LEVEL.DEBUG : LOG_LEVEL.WARN);
+        Purchases.configure({ apiKey });
+        Purchases.addCustomerInfoUpdateListener(customerInfoListener);
+
+        const customerInfo = await Purchases.getCustomerInfo();
+
+        if (isMounted) {
+          applyCustomerInfo(customerInfo);
+          setIsConfigured(true);
+          setError(null);
+        }
+      } catch (configurationError) {
+        if (isMounted) {
+          setError(configurationError?.message || "RevenueCat setup failed.");
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    configurePurchases();
+
+    return () => {
+      isMounted = false;
+      Purchases.removeCustomerInfoUpdateListener(customerInfoListener);
+    };
+  }, [applyCustomerInfo]);
+
+  const value = React.useMemo(
+    () => ({
+      isPremium,
+      isConfigured,
+      isEnabled: PREMIUM_ENABLED,
+      isLoading,
+      error,
+      refreshCustomerInfo,
+    }),
+    [error, isConfigured, isLoading, isPremium, refreshCustomerInfo]
+  );
+
+  return (
+    <PremiumContext.Provider value={value}>{children}</PremiumContext.Provider>
+  );
+};
+
+export const usePremium = () => React.useContext(PremiumContext);

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-native-google-mobile-ads": "^15.7.0",
         "react-native-maps": "1.20.1",
         "react-native-paper": "^5.13.1",
+        "react-native-purchases": "^10.2.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
@@ -2777,6 +2778,27 @@
         "react-native-safe-area-context": ">= 4.0.0",
         "react-native-screens": ">= 4.0.0"
       }
+    },
+    "node_modules/@revenuecat/purchases-js": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js/-/purchases-js-1.41.1.tgz",
+      "integrity": "sha512-v6vunZZ4YnQhR/O4W3cVhw3iE8O8fhloNA9Al3KU6ABiH6YGjflJiOhjbTp8JG78eUOlYUFYZwEU8H0VXSuiYA==",
+      "license": "MIT"
+    },
+    "node_modules/@revenuecat/purchases-js-hybrid-mappings": {
+      "version": "18.8.0",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js-hybrid-mappings/-/purchases-js-hybrid-mappings-18.8.0.tgz",
+      "integrity": "sha512-wGFEhf/n2AF9HmBd88UBrhISvxvi1Yrw8LtXtcdnZJ7akWI+W/Oo6PL44HsiptuWQBw2UYDeoL7ZKZhgBk7mTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@revenuecat/purchases-js": "1.41.1"
+      }
+    },
+    "node_modules/@revenuecat/purchases-typescript-internal": {
+      "version": "18.8.0",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal/-/purchases-typescript-internal-18.8.0.tgz",
+      "integrity": "sha512-y8p8wa0HFhfu0Rel/dp2aPpw+xhvPN0HlcQbK84B5+rzXCpIIpHONv2grgOtUlVWq6amv4lAn9rmooVr8xa50g==",
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -7702,6 +7724,31 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/react-native-purchases": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-purchases/-/react-native-purchases-10.2.0.tgz",
+      "integrity": "sha512-pIofFf1njbFTko5NTC+5Jv9U6lpUD6iPyHINUjMtIeIGNfQoudYTdctFSTIC/ahHHmX9SGf1QNkUHuJ1Qw5CLg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/purchaseTesterTypescript",
+        "react-native-purchases-ui",
+        "e2e-tests/MaestroTestApp"
+      ],
+      "dependencies": {
+        "@revenuecat/purchases-js-hybrid-mappings": "18.8.0",
+        "@revenuecat/purchases-typescript-internal": "18.8.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.6.3",
+        "react-native": ">= 0.73.0",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-native-google-mobile-ads": "^15.7.0",
     "react-native-maps": "1.20.1",
     "react-native-paper": "^5.13.1",
+    "react-native-purchases": "^10.2.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",

--- a/scripts/googlePlayRelease.test.js
+++ b/scripts/googlePlayRelease.test.js
@@ -35,16 +35,18 @@ test("Google Play release has native AdMob app id metadata", () => {
   );
 });
 
-test("Google Play ad release does not ship the incomplete premium billing flow", () => {
+test("Premium foundation is installed without exposing purchase UI or hiding ads", () => {
   const app = read("App.tsx");
   const adBanner = read("components/AdBanner.js");
   const settings = read("screens/SettingsScreen.js");
+  const premiumContext = read("context/PremiumContext.js");
   const androidManifest = read("android/app/src/main/AndroidManifest.xml");
   const packageJson = requireFromRoot("package.json");
 
-  assert.doesNotMatch(app, /PremiumProvider|PremiumContext/);
+  assert.match(app, /PremiumProvider/);
+  assert.match(premiumContext, /EXPO_PUBLIC_PREMIUM_ENABLED/);
   assert.doesNotMatch(adBanner, /usePremium|PremiumContext/);
   assert.doesNotMatch(settings, /usePremium|purchasePremium|restorePurchases/);
-  assert.doesNotMatch(androidManifest, /com\.android\.vending\.BILLING/);
-  assert.equal(packageJson.dependencies["react-native-purchases"], undefined);
+  assert.match(androidManifest, /com\.android\.vending\.BILLING/);
+  assert.equal(packageJson.dependencies["react-native-purchases"], "^10.2.0");
 });


### PR DESCRIPTION
## Summary
- Add RevenueCat premium foundation behind `EXPO_PUBLIC_PREMIUM_ENABLED`.
- Re-add Billing permission and `react-native-purchases` so Google Play can recognize in-app billing capability.
- Wrap the app in a safe `PremiumProvider` that stays no-op when premium is disabled or keys are missing.
- Keep purchase UI and ad hiding out of scope for this PR.

## Validation
- `node --test scripts/googlePlayRelease.test.js` -> 3/3 passing
- `npm exec tsc -- --noEmit` -> exit 0
- `npm exec expo -- config --json` -> Billing permission present
- `ANDROID_HOME=/Users/rafalciesielski/Library/Android/sdk ANDROID_SDK_ROOT=/Users/rafalciesielski/Library/Android/sdk ./gradlew :app:processDebugResources -Dkotlin.compiler.execution.strategy=in-process` -> BUILD SUCCESSFUL
- Generated debug manifest contains `com.android.vending.BILLING` and AdMob `com.google.android.gms.ads.APPLICATION_ID`

## Notes
- Do not merge until review is complete.
- Next PR: `feat/9-premium-settings-purchase` for Settings UI, buy, and restore.