### PR TITLE
fix(android): declare advertising id permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="com.android.vending.BILLING"/>
+  <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>

--- a/scripts/googlePlayRelease.test.js
+++ b/scripts/googlePlayRelease.test.js
@@ -27,6 +27,7 @@ test("Google Play release has native AdMob app id metadata", () => {
 
   assert.match(androidManifest, /com\.google\.android\.gms\.ads\.APPLICATION_ID/);
   assert.match(androidManifest, /@string\/admob_app_id/);
+  assert.match(androidManifest, /com\.google\.android\.gms\.permission\.AD_ID/);
   assert.match(
     strings,
     new RegExp(


### PR DESCRIPTION
## Summary
- Explicitly declare `com.google.android.gms.permission.AD_ID` in the Android source manifest.
- Add a release guard test so the permission remains present alongside AdMob metadata.

## Context
Play Console reported that an active artifact declaration says the app uses the advertising ID while one active manifest did not include the AD_ID permission. Google Mobile Ads already contributes this in merged manifests, but declaring it directly in the app manifest removes ambiguity for future Play uploads.

## Validation
- `node --test scripts/googlePlayRelease.test.js`
- `node --test scripts/settingsScreen.test.js`
- `npm exec tsc -- --noEmit`
- `./gradlew :app:processReleaseManifestForPackage`
- Verified generated release manifests contain `com.google.android.gms.permission.AD_ID`.