### PR TITLE
fix(android): allow EAS signing without key properties

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,11 +3,6 @@ apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
-def requestedReleaseTask = gradle.startParameter.taskNames.any { taskName ->
-    taskName.toLowerCase().contains("release")
-}
-def isEasBuild = System.getenv("EAS_BUILD") == "true"
-def easBuildGradle = file("./eas-build.gradle")
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -119,10 +114,8 @@ android {
                 keyAlias keystoreProperties["keyAlias"]
                 keyPassword keystoreProperties["keyPassword"]
             } else {
-                if (requestedReleaseTask && !isEasBuild && !easBuildGradle.exists()) {
-                    throw new FileNotFoundException("ERROR: key.properties file not found at expected location: " + keystorePropertiesFile)
-                }
-
+                // EAS injects the release signing config during build setup.
+                // Keep a local fallback so Gradle can evaluate the project without key.properties.
                 storeFile file('debug.keystore')
                 storePassword 'android'
                 keyAlias 'androiddebugkey'

--- a/scripts/googlePlayRelease.test.js
+++ b/scripts/googlePlayRelease.test.js
@@ -63,12 +63,9 @@ test("Premium purchase flow is available without hiding ads yet", () => {
 test("EAS Android builds can inject remote signing credentials", () => {
   const appBuildGradle = read("android/app/build.gradle");
 
-  assert.match(appBuildGradle, /eas-build\.gradle/);
-  assert.match(appBuildGradle, /easBuildGradle\.exists\(\)/);
-  assert.match(appBuildGradle, /System\.getenv\("EAS_BUILD"\)/);
-  assert.match(appBuildGradle, /isEasBuild/);
-  assert.doesNotMatch(
-    appBuildGradle,
-    /if \(requestedReleaseTask && !easBuildGradle\.exists\(\)\)/
-  );
+  assert.match(appBuildGradle, /EAS injects the release signing config/);
+  assert.match(appBuildGradle, /key\.properties/);
+  assert.doesNotMatch(appBuildGradle, /FileNotFoundException/);
+  assert.doesNotMatch(appBuildGradle, /requestedReleaseTask/);
+  assert.doesNotMatch(appBuildGradle, /System\.getenv\("EAS_BUILD"\)/);
 });


### PR DESCRIPTION
## Summary
- remove the hard failure when `android/key.properties` is missing during release Gradle configuration
- keep a local fallback so EAS can inject remote signing credentials before bundling
- update the Google Play release regression test for the signing flow

## Verification
- `node --test scripts/googlePlayRelease.test.js scripts/dailyCountry.test.js scripts/dailyCountryHome.test.js scripts/settingsScreen.test.js`
- `npm exec tsc -- --noEmit`

## Notes
Remote EAS build could not be started because the Expo Free plan Android build quota is exhausted until 2026-07-01.
Local EAS build confirmed the blocker: `key.properties file not found`.