### PR TITLE
Fix/115 android release and countries api

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,6 +15,7 @@ react {
     hermesCommand = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/sdks/hermesc/%OS-BIN%/hermesc"
     codegenDir = new File(["node", "--print", "require.resolve('@react-native/codegen/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
 
+    enableBundleCompression = (findProperty('android.enableBundleCompression') ?: false).toBoolean()
     // Use Expo CLI to bundle the app, this ensures the Metro config
     // works correctly with Expo projects.
     cliFile = new File(["node", "--print", "require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })"].execute(null, rootDir).text.trim())
@@ -80,7 +81,7 @@ def enableProguardInReleaseBuilds = (findProperty('android.enableProguardInRelea
  * give correct results when using with locales other than en-US. Note that
  * this variant is about 6MiB larger per architecture than default.
  */
-def jscFlavor = 'org.webkit:android-jsc:+'
+def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
 android {
     ndkVersion rootProject.ext.ndkVersion
@@ -93,7 +94,7 @@ android {
         applicationId 'com.adateo.WorldExplorer'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 92
+        versionCode 124
         versionName "1.2.2"
     }
     signingConfigs {
@@ -111,7 +112,7 @@ android {
                 keystorePropertiesFile.withInputStream { stream ->
                     keystoreProperties.load(stream)
                 }
-                storeFile file(rootProject.file(keystoreProperties["storeFile"]))
+                storeFile rootProject.file(keystoreProperties["storeFile"])
                 storePassword keystoreProperties["storePassword"]
                 keyAlias keystoreProperties["keyAlias"]
                 keyPassword keystoreProperties["keyPassword"]
@@ -129,11 +130,12 @@ android {
         debug {
             signingConfig signingConfigs.debug
         }
-         release {
+        release {
             signingConfig signingConfigs.release
-            shrinkResources true
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+            shrinkResources (findProperty('android.enableShrinkResourcesInReleaseBuilds')?.toBoolean() ?: false)
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            crunchPngs (findProperty('android.enablePngCrunchInReleaseBuilds')?.toBoolean() ?: true)
         }
     }
     packagingOptions {
@@ -180,15 +182,15 @@ dependencies {
 
     if (isGifEnabled) {
         // For animated gif support
-        implementation("com.facebook.fresco:animated-gif:${reactAndroidLibs.versions.fresco.get()}")
+        implementation("com.facebook.fresco:animated-gif:${expoLibs.versions.fresco.get()}")
     }
 
     if (isWebpEnabled) {
         // For webp support
-        implementation("com.facebook.fresco:webpsupport:${reactAndroidLibs.versions.fresco.get()}")
+        implementation("com.facebook.fresco:webpsupport:${expoLibs.versions.fresco.get()}")
         if (isWebpAnimatedEnabled) {
             // Animated webp support
-            implementation("com.facebook.fresco:animated-webp:${reactAndroidLibs.versions.fresco.get()}")
+            implementation("com.facebook.fresco:animated-webp:${expoLibs.versions.fresco.get()}")
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
+def easBuildGradle = file("./eas-build.gradle")
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -18,6 +19,7 @@ react {
     // works correctly with Expo projects.
     cliFile = new File(["node", "--print", "require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })"].execute(null, rootDir).text.trim())
     bundleCommand = "export:embed"
+    extraPackagerArgs = ["--max-workers", "1", "--reset-cache"]
 
     /* Folders */
      //   The root of your project, i.e. where "package.json" lives. Default is '../..'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,44 +1,37 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext {
-        buildToolsVersion = findProperty('android.buildToolsVersion') ?: '35.0.0'
-        minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
-        compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '35')
-        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '35')
-        kotlinVersion = findProperty('android.kotlinVersion') ?: '2.0.21'
-        ndkVersion = "27.1.12297006"
-        kspVersion = "2.0.21-1.0.28"
-    }
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.8.2")
-        classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    }
+  repositories {
+    google()
+    mavenCentral()
+  }
+  dependencies {
+    classpath('com.android.tools.build:gradle')
+    classpath('com.facebook.react:react-native-gradle-plugin')
+    classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
+  }
 }
 
-apply plugin: "com.facebook.react.rootproject"
+def reactNativeAndroidDir = new File(
+  providers.exec {
+    workingDir(rootDir)
+    commandLine("node", "--print", "require.resolve('react-native/package.json')")
+  }.standardOutput.asText.get().trim(),
+  "../android"
+)
 
 allprojects {
-    repositories {
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url(new File(['node', '--print', "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), '../android'))
-        }
-        maven {
-            // Android JSC is installed from npm
-            url(new File(['node', '--print', "require.resolve('jsc-android/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim(), '../dist'))
-        }
-
-        google()
-        mavenCentral()
-        maven { url 'https://www.jitpack.io' }
-        maven { url("$rootDir/../node_modules/react-native/android") }
+  repositories {
+    maven {
+      // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+      url(reactNativeAndroidDir)
     }
+
+    google()
+    mavenCentral()
+    maven { url 'https://www.jitpack.io' }
+  }
 }
+
+apply plugin: "expo-root-project"
+apply plugin: "com.facebook.react.rootproject"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/gradlew
+++ b/android/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,38 +1,39 @@
 pluginManagement {
-    includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().toString())
+  def reactNativeGradlePlugin = new File(
+    providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })")
+    }.standardOutput.asText.get().trim()
+  ).getParentFile().absolutePath
+  includeBuild(reactNativeGradlePlugin)
+  
+  def expoPluginsPath = new File(
+    providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })")
+    }.standardOutput.asText.get().trim(),
+    "../android/expo-gradle-plugin"
+  ).absolutePath
+  includeBuild(expoPluginsPath)
 }
-plugins { id("com.facebook.react.settings") }
+
+plugins {
+  id("com.facebook.react.settings")
+  id("expo-autolinking-settings")
+}
 
 extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
   if (System.getenv('EXPO_USE_COMMUNITY_AUTOLINKING') == '1') {
     ex.autolinkLibrariesFromCommand()
   } else {
-    def command = [
-      'node',
-      '--no-warnings',
-      '--eval',
-      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
-      'react-native-config',
-      '--json',
-      '--platform',
-      'android'
-    ].toList()
-    ex.autolinkLibrariesFromCommand(command)
+    ex.autolinkLibrariesFromCommand(expoAutolinking.rnConfigCommand)
   }
 }
+expoAutolinking.useExpoModules()
 
 rootProject.name = 'WorldExplorer'
 
-dependencyResolutionManagement {
-  versionCatalogs {
-    reactAndroidLibs {
-      from(files(new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../gradle/libs.versions.toml")))
-    }
-  }
-}
-
-apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle");
-useExpoModules()
+expoAutolinking.useExpoVersionCatalog()
 
 include ':app'
-includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile())
+includeBuild(expoAutolinking.reactNativeGradlePlugin)

--- a/app.config.js
+++ b/app.config.js
@@ -25,8 +25,11 @@ module.exports = {
     },
     android: {
       package: "com.adateo.WorldExplorer",
-      versionCode: 92,
-      permissions: ["com.android.vending.BILLING"],
+      versionCode: 124,
+      permissions: [
+        "com.google.android.gms.permission.AD_ID",
+        "com.android.vending.BILLING",
+      ],
       adaptiveIcon: {
         foregroundImage: "./assets/adaptive-icon.png",
         backgroundColor: "#ffffff",

--- a/constants.js
+++ b/constants.js
@@ -1,1 +1,17 @@
-export const API_URL = "https://restcountries.com/v3.1/all";
+export const COUNTRY_LIST_FIELDS = [
+  "name",
+  "flags",
+  "capital",
+  "cca3",
+  "population",
+  "region",
+  "subregion",
+  "languages",
+  "currencies",
+  "latlng",
+].join(",");
+
+export const QUIZ_COUNTRY_FIELDS = ["name", "flags", "capital"].join(",");
+
+export const API_URL = `https://restcountries.com/v3.1/all?fields=${COUNTRY_LIST_FIELDS}`;
+export const QUIZ_API_URL = `https://restcountries.com/v3.1/all?fields=${QUIZ_COUNTRY_FIELDS}`;

--- a/screens/ExploreScreen.js
+++ b/screens/ExploreScreen.js
@@ -28,7 +28,7 @@ const ExploreScreen = ({ navigation }) => {
 
   React.useEffect(() => {
     axios
-      .get("https://restcountries.com/v3.1/all")
+      .get("https://restcountries.com/v3.1/all?fields=name,flags")
       .then((response) => {
         setCountries(response.data);
       })
@@ -37,7 +37,7 @@ const ExploreScreen = ({ navigation }) => {
   }, []);
 
   const filteredCountries = countries.filter((country) =>
-    country.name.common.toLowerCase().startsWith(searchQuery.toLowerCase())
+    country.name.common.toLowerCase().startsWith(searchQuery.toLowerCase()),
   );
 
   const renderItem = ({ item }) => (

--- a/screens/ExploreScreen.js
+++ b/screens/ExploreScreen.js
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { ThemeContext } from "../context/ThemeContext";
 import { getStyles } from "../styles";
 import AdBanner from "../components/AdBanner";
+import { API_URL } from "../constants";
 
 const ExploreScreen = ({ navigation }) => {
   const [countries, setCountries] = React.useState([]);
@@ -28,7 +29,7 @@ const ExploreScreen = ({ navigation }) => {
 
   React.useEffect(() => {
     axios
-      .get("https://restcountries.com/v3.1/all?fields=name,flags")
+      .get(API_URL)
       .then((response) => {
         setCountries(response.data);
       })

--- a/screens/quiz/QuizScreen.js
+++ b/screens/quiz/QuizScreen.js
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { ThemeContext } from "../../context/ThemeContext";
 import { getStyles } from "../../styles";
 import AdBanner from "../../components/AdBanner";
+import { QUIZ_API_URL } from "../../constants";
 
 const {
   answerQuestion,
@@ -44,7 +45,7 @@ const QuizScreen = ({ route, navigation }) => {
 
     let isMounted = true;
     axios
-      .get("https://restcountries.com/v3.1/all")
+      .get(QUIZ_API_URL)
       .then((response) => {
         if (isMounted) {
           const countries = response.data;

--- a/scripts/googlePlayRelease.test.js
+++ b/scripts/googlePlayRelease.test.js
@@ -68,6 +68,9 @@ test("EAS Android builds can inject remote signing credentials", () => {
     appBuildGradle,
     /buildTypes\s*\{[\s\S]*?release\s*\{\s*signingConfig signingConfigs\.release/
   );
+  assert.match(appBuildGradle, /shrinkResources true/);
+  assert.match(appBuildGradle, /minifyEnabled true/);
+  assert.match(appBuildGradle, /getDefaultProguardFile\("proguard-android-optimize\.txt"\)/);
   assert.match(appBuildGradle, /def easBuildGradle = file\("\.\/eas-build\.gradle"\)/);
   assert.match(appBuildGradle, /if \(easBuildGradle\.exists\(\)\)/);
   assert.match(appBuildGradle, /apply from: easBuildGradle/);

--- a/scripts/googlePlayRelease.test.js
+++ b/scripts/googlePlayRelease.test.js
@@ -64,6 +64,10 @@ test("EAS Android builds can inject remote signing credentials", () => {
   const appBuildGradle = read("android/app/build.gradle");
 
   assert.match(appBuildGradle, /EAS injects the release signing config/);
+  assert.match(appBuildGradle, /def easBuildGradle = file\("\.\/eas-build\.gradle"\)/);
+  assert.match(appBuildGradle, /if \(easBuildGradle\.exists\(\)\)/);
+  assert.match(appBuildGradle, /apply from: easBuildGradle/);
+  assert.match(appBuildGradle, /extraPackagerArgs = \["--max-workers", "1", "--reset-cache"\]/);
   assert.match(appBuildGradle, /key\.properties/);
   assert.doesNotMatch(appBuildGradle, /FileNotFoundException/);
   assert.doesNotMatch(appBuildGradle, /requestedReleaseTask/);

--- a/scripts/googlePlayRelease.test.js
+++ b/scripts/googlePlayRelease.test.js
@@ -64,6 +64,10 @@ test("EAS Android builds can inject remote signing credentials", () => {
   const appBuildGradle = read("android/app/build.gradle");
 
   assert.match(appBuildGradle, /EAS injects the release signing config/);
+  assert.match(
+    appBuildGradle,
+    /buildTypes\s*\{[\s\S]*?release\s*\{\s*signingConfig signingConfigs\.release/
+  );
   assert.match(appBuildGradle, /def easBuildGradle = file\("\.\/eas-build\.gradle"\)/);
   assert.match(appBuildGradle, /if \(easBuildGradle\.exists\(\)\)/);
   assert.match(appBuildGradle, /apply from: easBuildGradle/);

--- a/scripts/restCountriesApi.test.js
+++ b/scripts/restCountriesApi.test.js
@@ -1,0 +1,29 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const rootDir = path.resolve(__dirname, "..");
+
+const read = (filePath) => fs.readFileSync(path.join(rootDir, filePath), "utf8");
+
+test("REST Countries all requests specify the fields required by each screen", () => {
+  const constants = read("constants.js");
+  const exploreScreen = read("screens/ExploreScreen.js");
+  const quizScreen = read("screens/quiz/QuizScreen.js");
+
+  assert.match(constants, /COUNTRY_LIST_FIELDS/);
+  assert.match(constants, /QUIZ_COUNTRY_FIELDS/);
+  assert.match(
+    constants,
+    /https:\/\/restcountries\.com\/v3\.1\/all\?fields=\$\{COUNTRY_LIST_FIELDS\}/
+  );
+  assert.match(
+    constants,
+    /https:\/\/restcountries\.com\/v3\.1\/all\?fields=\$\{QUIZ_COUNTRY_FIELDS\}/
+  );
+  assert.match(exploreScreen, /API_URL/);
+  assert.doesNotMatch(exploreScreen, /restcountries\.com\/v3\.1\/all(?!\?fields=)/);
+  assert.match(quizScreen, /QUIZ_API_URL/);
+  assert.doesNotMatch(quizScreen, /restcountries\.com\/v3\.1\/all(?!\?fields=)/);
+});


### PR DESCRIPTION
## Summary
- fix local Android release signing so generated AABs use the Google Play upload certificate instead of the debug key
- bump Android versionCode to 124 for the new store upload
- update REST Countries `/v3.1/all` calls to always include required `fields`
- refresh Android Gradle/Expo autolinking setup needed for the verified local release build
- add a regression test covering REST Countries fielded URLs