### PR TITLE
fix: Gradle autolinking and workflow naming

### DIFF
--- a/.github/workflows/update-countries.yml
+++ b/.github/workflows/update-countries.yml
@@ -1,4 +1,4 @@
-name: Monthly Countries Dataset Update
+name: Update Countries Data
 
 on:
   schedule:

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,6 @@
+apply from: file("../node_modules/expo-modules-core/android/autolinking.gradle")
+applyExpoModulesSettingsGradle()
+
 pluginManagement {
   def reactNativeGradlePlugin = new File(
     providers.exec {


### PR DESCRIPTION
## Summary

Resolve Gradle build configuration issues and standardize workflow naming.

## Changes

### 1. Gradle Autolinking Fix
- **File:** `android/settings.gradle`
- **Fix:** Added explicit Expo autolinking configuration
- **Resolves:** 'Project with path :expo-json-utils could not be found' error
- **Details:** Gradle can now properly resolve all Expo modules in CI/CD builds

### 2. Workflow Naming Consistency
- **File:** `.github/workflows/update-countries.yml`
- **Change:** Renamed from 'Monthly Countries Dataset Update' to 'Update Countries Data'
- **Reason:** Matches naming pattern of other workflows (PR Validation, Build & Release AAB)

## Build Status

The CI/CD pipeline is now fully configured and ready:
- ✅ Expo autolinking enabled
- ✅ JDK 21 for Android SDK compatibility
- ✅ Production keystore signing
- ✅ Workflow naming standardized

## Test Plan
- Re-run CI/CD workflow (should complete without autolinking errors)
- Verify 'Update Countries Data' appears in GitHub Actions tab
- Monitor build logs for successful AAB generation